### PR TITLE
Updates for SR2024 - Add the message content intent

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ logger.addHandler(handler)
 
 intents = discord.Intents.default()
 intents.members = True  # Listen to member joins
+intents.message_content = True  # Read the contents of messages
 
 client = discord.Client(intents=intents)
 


### PR DESCRIPTION
The current Discord API now requires an additional intent to be able to read messages.

Closes #21