### PR TITLE
Improve error logging messages

### DIFF
--- a/src/sr/discord_bot/bot.py
+++ b/src/sr/discord_bot/bot.py
@@ -69,7 +69,7 @@ class BotClient(discord.Client):
         self.tree = app_commands.CommandTree(self)
         guild_id = os.getenv('DISCORD_GUILD_ID')
         if guild_id is None or not guild_id.isnumeric():
-            self.logger.error("Invalid guild ID")
+            self.logger.error("Invalid guild ID: %r", guild_id)
             exit(1)
         self.guild = discord.Object(id=int(guild_id))
         team = Team()
@@ -98,39 +98,63 @@ class BotClient(discord.Client):
 
     async def on_ready(self) -> None:
         self.logger.info(f"{self.user} has connected to Discord!")
-        guild = self.get_guild(self.guild.id)
-        if guild is None:
-            logging.error(f"Guild {self.guild.id} not found!")
+
+        if (guild := self.get_guild(self.guild.id)) is None:
+            self.logger.error("Guild not found: %r", self.guild.id)
+
+            # If the guild can't be refreshed, terminate here rather than continuing to
+            # validate known-stale data.
             exit(1)
+
         self.guild = guild
 
-        verified_role = discord.utils.get(guild.roles, name=VERIFIED_ROLE)
-        special_role = discord.utils.get(guild.roles, name=SPECIAL_ROLE)
-        volunteer_role = discord.utils.get(guild.roles, name=VOLUNTEER_ROLE)
-        supervisor_role = discord.utils.get(guild.roles, name=TEAM_LEADER_ROLE)
-        welcome_category = discord.utils.get(guild.categories, name=WELCOME_CATEGORY_NAME)
-        announce_channel = discord.utils.get(guild.text_channels, name=ANNOUNCE_CHANNEL_NAME)
-        feed_channel = discord.utils.get(guild.text_channels, name=FEED_CHANNEL_NAME)
+        setup_correctly = True
 
-        if (
-            verified_role is None
-            or special_role is None
-            or volunteer_role is None
-            or supervisor_role is None
-            or welcome_category is None
-            or announce_channel is None
-            or feed_channel is None
-        ):
-            logging.error("Roles and channels are not set up")
-            exit(1)
+        if (verified_role := discord.utils.get(guild.roles, name=VERIFIED_ROLE)) is None:
+            self.logger.error("Unable to find role: %r", VERIFIED_ROLE)
+            setup_correctly = False
         else:
             self.verified_role = verified_role
+
+        if (special_role := discord.utils.get(guild.roles, name=SPECIAL_ROLE)) is None:
+            self.logger.error("Unable to find role: %r", SPECIAL_ROLE)
+            setup_correctly = False
+        else:
             self.special_role = special_role
+
+        if (volunteer_role := discord.utils.get(guild.roles, name=VOLUNTEER_ROLE)) is None:
+            self.logger.error("Unable to find volunteer role: %r", VOLUNTEER_ROLE)
+            setup_correctly = False
+        else:
             self.volunteer_role = volunteer_role
+
+        if (supervisor_role := discord.utils.get(guild.roles, name=TEAM_LEADER_ROLE)) is None:
+            self.logger.error("Unable to find team supervisor role: %r", VOLUNTEER_ROLE)
+            setup_correctly = False
+        else:
             self.supervisor_role = supervisor_role
+
+        if (welcome_category := discord.utils.get(guild.categories, name=WELCOME_CATEGORY_NAME)) is None:
+            self.logger.error("Unable to find welcome category: %r", WELCOME_CATEGORY_NAME)
+            setup_correctly = False
+        else:
             self.welcome_category = welcome_category
+
+        if (announce_channel := discord.utils.get(guild.text_channels, name=ANNOUNCE_CHANNEL_NAME)) is None:
+            self.logger.error("Unable to find announcement channel: %r", ANNOUNCE_CHANNEL_NAME)
+            setup_correctly = False
+        else:
             self.announce_channel = announce_channel
+
+        if (feed_channel := discord.utils.get(guild.text_channels, name=FEED_CHANNEL_NAME)) is None:
+            self.logger.error("Unable to find feed channel: %r", FEED_CHANNEL_NAME)
+            setup_correctly = False
+        else:
             self.feed_channel = feed_channel
+
+        if not setup_correctly:
+            self.logger.error("Roles and channels are not set up correctly - Terminating.")
+            exit(1)
 
         self.teams_data.gen_team_memberships(self.guild, self.supervisor_role)
         await self.update_subscribed_messages()

--- a/src/sr/discord_bot/bot.py
+++ b/src/sr/discord_bot/bot.py
@@ -69,7 +69,7 @@ class BotClient(discord.Client):
         self.tree = app_commands.CommandTree(self)
         guild_id = os.getenv('DISCORD_GUILD_ID')
         if guild_id is None or not guild_id.isnumeric():
-            self.logger.error("Invalid guild ID: %r", guild_id)
+            self.logger.critical("Invalid guild ID: %r", guild_id)
             exit(1)
         self.guild = discord.Object(id=int(guild_id))
         team = Team()
@@ -153,7 +153,7 @@ class BotClient(discord.Client):
             self.feed_channel = feed_channel
 
         if not setup_correctly:
-            self.logger.error("Roles and channels are not set up correctly - Terminating.")
+            self.logger.critical("Roles and channels are not set up correctly - Terminating.")
             exit(1)
 
         self.teams_data.gen_team_memberships(self.guild, self.supervisor_role)

--- a/src/sr/discord_bot/commands/join.py
+++ b/src/sr/discord_bot/commands/join.py
@@ -57,7 +57,11 @@ async def join(interaction: discord.Interaction["BotClient"], password: str) -> 
         # Add them to that specific role
         specific_role = discord.utils.get(guild.roles, name=role_name)
         if specific_role is None:
-            interaction.client.logger.error(f"Specified role '{chosen_team}' does not exist")
+            interaction.client.logger.error(
+                "Specified role %r does not exist - unable to assign to %s",
+                role_name,
+                member.name,
+            )
         else:
             await member.add_roles(
                 specific_role,

--- a/src/sr/discord_bot/commands/logs.py
+++ b/src/sr/discord_bot/commands/logs.py
@@ -97,7 +97,7 @@ async def get_team_channel(
     if not isinstance(tla_search, re.Match):
         await log_and_reply(
             ctx,
-            f"# Failed to extract a TLA from {archive_name} in {zip_name}",
+            f"# Failed to extract a TLA from {archive_name!r} in {zip_name}",
         )
         return '', None
 
@@ -125,7 +125,7 @@ def pre_test_zipfile(archive_name: str, zip_name: str) -> bool:
 def match_animation_files(log_name: str, animation_dir: Path) -> List[Path]:
     match_num_search = re.search(r'match-([0-9]+)', log_name)
     if not isinstance(match_num_search, re.Match):
-        logger.warning(f'Invalid match name: {log_name}')
+        logger.warning('Invalid match name %r when sending logs', log_name)
         return []
     match_num = match_num_search[1]
     logger.debug(f"Fetching animation files for match {match_num}")
@@ -191,18 +191,18 @@ async def send_file(
 
 
 def extract_animations(zipfile: ZipFile, tmpdir: Path, fully_extract: bool) -> bool:
-    animation_files = [
-        name for name in zipfile.namelist()
-        if name.split('/')[-1].startswith('animations') and name.endswith('.zip')
-    ]
-
-    if not animation_files:
-        return False
-
     try:
+        animation_files = [
+            name for name in zipfile.namelist()
+            if name.split('/')[-1].startswith('animations') and name.endswith('.zip')
+        ]
+
+        if not animation_files:
+            return False
+
         zipfile.extract(animation_files[0], path=tmpdir)
     except BadZipFile:
-        logger.warning("The animations zip was corrupt")
+        logger.exception("The animations zip was corrupt")
         return False
 
     # give the animations archive + folder if fixed name


### PR DESCRIPTION
Fixes #47 

When `on_ready` reported that the guild wasn't configured correctly, it wasn't possible to identify why, as all errors were grouped together. This PR separates them, showing exactly why it failed, ensuring we get all messages rather than just the first to validate.

Similarly, a few other log messages have some more context added, so it's clearer from the text logs why they're being displayed. #42 also achieves this, but better log messages can't hurt anyway!