### PR TITLE
Update access instructions to use '/join' command

### DIFF
--- a/messages/welcome-and-rules.md
+++ b/messages/welcome-and-rules.md
@@ -14,4 +14,4 @@ Hopefully we won't need to, but we will raise violations of these rules to your 
 
 You should have already been sent a welcome message by $bot, in your very own `#welcome-<yourname>` channel.
 
-To get access, send a message in that channel with your **team password** (which was emailed to your team supervisor). Once you do this, you will automatically be given access.
+To get access, use the `/join` command with your **team password** (which was emailed to your team supervisor). Once you do this, you will automatically be given access.


### PR DESCRIPTION
We've seen some people just post their password in their welcome channel. I wonder if this is why.